### PR TITLE
README.mdにER図の画像を添付

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## ER diagram
 
-![ER diagram](./public/images/fleamarket_sample_73c.png)
+![ER diagram](https://user-images.githubusercontent.com/63594128/92335028-fbb31180-f0cd-11ea-84cb-4a67c719b3db.png)
 
 ## users
 


### PR DESCRIPTION
＃What
READMEにER図を添付

＃Why
table同士の関係が一目見ただけで分かるようにする為